### PR TITLE
Updated Rectify11.nl.resx

### DIFF
--- a/Rectify11Installer/Strings/Rectify11.nl.resx
+++ b/Rectify11Installer/Strings/Rectify11.nl.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="buttonAgree" xml:space="preserve">
-    <value>Mee eens</value>
+    <value>Akkoord</value>
   </data>
   <data name="buttonCancel" xml:space="preserve">
     <value>Annuleren</value>
@@ -136,19 +136,19 @@
     <value>Voordat u Rectify11 kunt installeren, moet u akkoord gaan met deze licentieovereenkomst:</value>
   </data>
   <data name="installNote" xml:space="preserve">
-    <value>Herstel uw huidige Windows-installatie.</value>
+    <value>Rectificeer uw huidige Windows-installatie.</value>
   </data>
   <data name="installTitle" xml:space="preserve">
-    <value>Nu installeren</value>
+    <value>Nu installeer nu</value>
   </data>
   <data name="uninstallNote" xml:space="preserve">
-    <value>Herstelt het oorspronkelijke Windows uiterlijk.</value>
+    <value>Herstelt het oorspronkelijke Windows-uiterlijk.</value>
   </data>
   <data name="uninstallTitle" xml:space="preserve">
-    <value>Rectify11 verwijderen</value>
+    <value>Verwijder Rectify11</value>
   </data>
   <data name="updateNote" xml:space="preserve">
-    <value>Update uw bestaande Rectify11 installatie.</value>
+    <value>Update uw bestaande Rectify11-installatie.</value>
   </data>
   <data name="updateTitle" xml:space="preserve">
     <value>Nu bijwerken</value>
@@ -163,7 +163,7 @@
     <value>De setup zal de verschillende stappen doorlopen die nodig zijn om Rectify11 op uw PC te installeren, voor een meer consistente ervaring. Selecteer de gewenste optie om verder te gaan.</value>
   </data>
   <data name="installChoiceDescription" xml:space="preserve">
-    <value>U kunt kiezen wat verbeterd zal worden.</value>
+    <value>U kunt kiezen wat gerectificeerd zal worden.</value>
   </data>
   <data name="installChoiceTitle" xml:space="preserve">
     <value>Kies wat u wilt installeren</value>
@@ -172,10 +172,10 @@
     <value>Selecteer uw gewenste thema.</value>
   </data>
   <data name="themeHeader" xml:space="preserve">
-    <value>Personaliseer uw systeem</value>
+    <value>Personaliseer uw ervaring</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Rectify11 Installatie</value>
+    <value>Rectify11-Installatie</value>
   </data>
   <data name="themeBlack" xml:space="preserve">
     <value>Donker met Mica</value>
@@ -190,34 +190,34 @@
     <value>Verbeterd lint gebruiken</value>
   </data>
   <data name="epExtMica" xml:space="preserve">
-    <value>Mica uitbreiden naar de navigatiebalk van verkenner</value>
+    <value>Mica uitbreiden naar de navigatiebalk van de verkenner</value>
   </data>
   <data name="epHeader" xml:space="preserve">
     <value>Uw bureaublad aanpassen</value>
   </data>
   <data name="epTitle" xml:space="preserve">
-    <value>Selecteer uw gewenste desktopervaring</value>
+    <value>Selecteer uw gewenste bureaubladervaring</value>
   </data>
   <data name="epW10Radio" xml:space="preserve">
-    <value>Windows 10 Afgerond</value>
+    <value>Windows 10-Afgerond</value>
   </data>
   <data name="epW10Taskbar" xml:space="preserve">
-    <value>Windows 10 Taakbalk</value>
+    <value>Windows 10-Taakbalk</value>
   </data>
   <data name="epW11Radio" xml:space="preserve">
-    <value>Windows 11 Standaard</value>
+    <value>Windows 11-Standaard</value>
   </data>
   <data name="progressText" xml:space="preserve">
     <value>Wist je dat</value>
   </data>
   <data name="summaryFooter" xml:space="preserve">
-    <value>Sluit alle geopende programma's af en sla uw werk op, want aan het eind van de installatie wordt het systeem opnieuw opgestart.</value>
+    <value>Sluit alstublieft al uw geopende programma's en sla uw werk op, want uw systeem wordt opnieuw opgestart op het einde van de installatie.</value>
   </data>
   <data name="summaryItems" xml:space="preserve">
-    <value>Installeer Rectify11 op deze Windows installatie.</value>
+    <value>Installeer Rectify11 op deze Windows-installatie.</value>
   </data>
   <data name="summaryTitle" xml:space="preserve">
-    <value>Je staat op het punt om het volgende te doen:</value>
+    <value>U staat op het punt om het volgende te doen:</value>
   </data>
   <data name="buttonInstall" xml:space="preserve">
     <value>Installeer</value>
@@ -232,7 +232,7 @@
     <value>Thema's</value>
   </data>
   <data name="optionWallpaper" xml:space="preserve">
-    <value>Rectify11 achtergronden</value>
+    <value>Rectify11-achtergronden</value>
   </data>
   <data name="installEP" xml:space="preserve">
     <value>Installeer ExplorerPatcher</value>
@@ -244,7 +244,7 @@
     <value>Installeer thema's</value>
   </data>
   <data name="installWallpapers" xml:space="preserve">
-    <value>Rectify11 achtergronden</value>
+    <value>Installeer achtergronden</value>
   </data>
   <data name="installWinver" xml:space="preserve">
     <value>Installeer Winver</value>
@@ -257,6 +257,24 @@
     <value>Samenvatting</value>
   </data>
   <data name="exitText" xml:space="preserve">
-    <value>Weet je zeker dat je de installatie wilt annuleren?</value>
+    <value>Weet je zeker dat je de installatie wil annuleren?</value>
   </data>
+    </data>
+  <data name="buttonReboot" xml:space="preserve">
+    <value>Nu opnieuw opstarten</value>
+  </data>
+  <data name="installASDF" xml:space="preserve">
+    <value>Installeer Accent Colorizer</value>
+  </data>
+  <data name="installIcons" xml:space="preserve">
+    <value>Vervang icoontjes</value>
+  </data>
+  <data name="userAvatars" xml:space="preserve">
+    <value>Installeer profielfoto's</value>
+  </data>
+  <data name="CMenuPageHeader" xml:space="preserve">
+    <value>rechtermuisknopmenu-stijl</value>
+  </data>
+  <data name="installGadgets" xml:space="preserve">
+    <value>Installeer Gadgets</value>
 </root>


### PR DESCRIPTION
Made the Dutch language more consistent with the English version, and added strings that were present in the English file, but not in the Dutch one, at the end of the file. (Please remove those if that is not the correct way to translate new strings.)